### PR TITLE
:construction_worker: GitHub CI/CD 재구축

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Deploy to Linux server
         env:
           SSH_HOST: ${{secrets.SSH_HOST}}
+          SSH_PORT: $${secrets.SSH_PORT}}
           SSH_USER: $${secrets.SSH_USER}}
           SSH_KEY: ${{secrets.SSH_KEY}}
         run: |
           echo "$SSH_KEY" > deploy_key
           chmod 600 deploy_key
-          scp -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null build/libs/*.jar $SSH_USER@$SSH_HOST:/tmp/app.jar
-          ssh -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SSH_USER@$SSH_HOST <<EOF
+          scp -P $SSH_PORT -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null build/libs/*.jar $SSH_USER@$SSH_HOST:/tmp/app.jar
+          ssh -p $SSH_PORT -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SSH_USER@$SSH_HOST <<EOF
             sudo mv /tmp/app.jar /opt/concheese/app.jar
             sudo systemctl restart concheese-server
           EOF

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           java-version: 17
           distribution: microsoft
+
       - name: Make env.properties
         run: |
           # Create env.properties

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,30 @@
+name: Spring Boot & Gradle CI/CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - feature/*
+  pull_request:
+    branches:
+    - main
+    - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3.5.3
+
+    - name: Setup JDK 17
+      uses: actions/setup-java@v3.12.0
+      with:
+        java-version: 17
+        distribution: microsoft
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew clean build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,9 +16,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3
@@ -26,17 +26,23 @@ jobs:
           java-version: 17
           distribution: microsoft
 
-      - name: Make env.properties
-        run: |
-          # Create env.properties
-          cd ./src/main/resources
-          touch ./env.properties
-          echo "DB_DATABASE=${{ secrets.DB_DATABASE }}" >> ./env.properties
-          echo "DB_USER=${{ secrets.DB_USER }}" >> ./env.properties
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ./env.properties
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean bootJar
+
+      - name: Deploy to Linux server
+        env:
+          SSH_HOST: ${{secrets.SSH_HOST}}
+          SSH_USER: $${secrets.SSH_USER}}
+          SSH_KEY: ${{secrets.SSH_KEY}}
+        run: |
+          echo "$SSH_KEY" > deploy_key
+          chmod 600 deploy_key
+          scp -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null build/libs/*.jar $SSH_USER@$SSH_HOST:/tmp/app.jar
+          ssh -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SSH_USER@$SSH_HOST <<EOF
+            sudo mv /tmp/app.jar /opt/concheese/app.jar
+            sudo systemctl restart concheese-server
+          EOF
+          rm -f deploy_key

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,27 +4,38 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - feature/*
+      - feature/*
   pull_request:
     branches:
-    - main
-    - dev
+      - main
+      - dev
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
 
-    - name: Setup JDK 17
-      uses: actions/setup-java@v3.12.0
-      with:
-        java-version: 17
-        distribution: microsoft
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: microsoft
+      - name: Make env.properties
+        run: |
+          # Create env.properties
+          cd ./src/main/resources
+          touch ./env.properties
+          echo "DB_DATABASE=${{ secrets.DB_DATABASE }}" >> ./env.properties
+          echo "DB_USER=${{ secrets.DB_USER }}" >> ./env.properties
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ./env.properties
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-    - name: Build with Gradle
-      run: ./gradlew clean build
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,7 +43,7 @@ jobs:
           chmod 600 deploy_key
           scp -P $SSH_PORT -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null build/libs/*.jar $SSH_USER@$SSH_HOST:/tmp/app.jar
           ssh -p $SSH_PORT -i deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SSH_USER@$SSH_HOST <<EOF
-            sudo mv /tmp/app.jar /opt/concheese/app.jar
-            sudo systemctl restart concheese-server
+            cp /tmp/app.jar /opt/concheese/app.jar
+            systemctl --user restart concheese-server
           EOF
           rm -f deploy_key

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Deploy to Linux server
         env:
           SSH_HOST: ${{secrets.SSH_HOST}}
-          SSH_PORT: $${secrets.SSH_PORT}}
-          SSH_USER: $${secrets.SSH_USER}}
+          SSH_PORT: ${{secrets.SSH_PORT}}
+          SSH_USER: ${{secrets.SSH_USER}}
           SSH_KEY: ${{secrets.SSH_KEY}}
         run: |
           echo "$SSH_KEY" > deploy_key


### PR DESCRIPTION
본 기능은 다음의 일련 과정을 지원합니다.

1. GitHub Action으로 프로젝트를 빌드
2. SCP를 이용해 Linux 서버로 파일 복사
3. Linux 서버에서 JAR 실행